### PR TITLE
Futureproof contributors links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,4 +18,4 @@ To stay on the list, projects should follow these quality standards:
 * Documented.
 * Tests.
 
-Thanks to all [contributors](./graphs/contributors), you're awesome and wouldn't be possible without you!
+Thanks to all [contributors](../../graphs/contributors), you're awesome and wouldn't be possible without you!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,4 +18,4 @@ To stay on the list, projects should follow these quality standards:
 * Documented.
 * Tests.
 
-Thanks to all [contributors](https://github.com/awesome-dragonruby/awesome-dragonruby/graphs/contributors), you're awesome and wouldn't be possible without you!
+Thanks to all [contributors](./graphs/contributors), you're awesome and wouldn't be possible without you!

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Sharing, suggestions and contributions are always welcome!
 
 Please take a look at the [contribution guidelines and quality standard](./CONTRIBUTING.md) first.
 
-Thanks to all [contributors](https://github.com/DragonRuby-community/awesome-dragonruby/graphs/contributors), you're awesome and this wouldn't be possible without you!
+Thanks to all [contributors](./graphs/contributors), you're awesome and this wouldn't be possible without you!
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Sharing, suggestions and contributions are always welcome!
 
 Please take a look at the [contribution guidelines and quality standard](./CONTRIBUTING.md) first.
 
-Thanks to all [contributors](./graphs/contributors), you're awesome and this wouldn't be possible without you!
+Thanks to all [contributors](../../graphs/contributors), you're awesome and this wouldn't be possible without you!
 
 ## License
 


### PR DESCRIPTION
The links to the contributors pages pointed still to the old repository - so I turned them into relative links