### PR TITLE
Add Dragonborn and Foodchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ _All samples in this section must link to freely available source code with an [
 * [Scale](https://github.com/DragonRidersUnite/scale) - Lightweight starter template with common helpers
 * [Smaug](https://smaug.dev/) - Installation and package manager for DragonRuby
 * [Zif](https://github.com/danhealy/dragonruby-zif) - A Drop-in Framework for DragonRuby Game Toolkit
+* [Dragonborn](https://github.com/pvande/dragonborn) - Automatically require your game's code (a la Rails / Zeitwerk)
+* [Foodchain](https://github.com/pvande/foodchain) - Manage and document your game's dependencies
 
 ## Documents & Tutorials & Presentations & Videos
 


### PR DESCRIPTION
Dragonborn is a code autoloader like [Zeitwerk](https://github.com/fxn/zeitwerk), made compatible with `mruby` and DragonRuby. This allows even complicated multi-file games to automatically resolve ordering dependencies between files without sacrificing the conveniences provided by DragonRuby (like hot loading).

Foodchain is a single-file library for documenting, downloading, and updating external dependencies. The goal is to provide an option that's less ad-hoc than `$gtk.download_stb_rb`, but which provides a similar level of convenience. Foodchain supports downloading from arbitrary URLs, as well as GitHub files and folders, and uses HTTP caching data to note when upgrades are available. (These files are also not restricted in where they can be saved or what types they may be, making it an acceptable option for pulling in sprites or music as well.)